### PR TITLE
Add pagination arguments property to Pagination class

### DIFF
--- a/src/Pagination.php
+++ b/src/Pagination.php
@@ -40,6 +40,13 @@ class Pagination implements PaginationContract {
      */
     protected $items = [];
 
+	/**
+     * Pagination arguments.
+     *
+     * @var array
+     */
+    protected $args = [];
+
     /**
      * The total number of pages.
      *


### PR DESCRIPTION
Fixes PHP 8.2+ warning:

> Creation of dynamic property Hybrid\Pagination\Pagination::$args is deprecated
> * wp-content/themes/example/vendor/themehybrid/hybrid-pagination/src/Pagination.php:149